### PR TITLE
ci: exclude test from snyk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,3 @@
+exclude:
+  global:
+    - packages/dapp-toolkit/src/modules/wallet-request/crypto/signature.spec.ts

--- a/packages/dapp-toolkit/src/modules/wallet-request/crypto/curve25519.spec.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/crypto/curve25519.spec.ts
@@ -20,7 +20,8 @@ describe('Curve25519', () => {
     expect(keyPair2.x25519.getPublicKey()).toBeDefined()
     expect(keyPair2.ed25519.getPublicKey()).toBeDefined()
   })
-  it.only('should calculate a shared secret', () => {
+  
+  it('should calculate a shared secret', () => {
     const sharedSecretResult = keyPair1.x25519.calculateSharedSecret(
       keyPair2.x25519.getPublicKey(),
       dAppDefinitionAddress,


### PR DESCRIPTION
snyk reports  "[High] Hardcoded Secret" in a spec file but we're fine with that