### PR TITLE
fix: `onShowPopover` attr changed callback

### DIFF
--- a/packages/connect-button/src/components/connect-button.ts
+++ b/packages/connect-button/src/components/connect-button.ts
@@ -42,7 +42,7 @@ export class ConnectButton extends LitElement {
   @property({ type: String })
   loggedInTimestamp: string = ''
 
-  @property({ type: Boolean })
+  @property({ type: Boolean, reflect: true })
   showPopoverMenu: boolean = false
 
   @property({ type: Array })
@@ -112,6 +112,7 @@ export class ConnectButton extends LitElement {
     super.attributeChangedCallback(name, _old, value)
     if (name === 'showpopovermenu') {
       this.pristine = false
+      this.toggleBodyOverflow()
     }
   }
 

--- a/packages/dapp-toolkit/src/modules/connect-button/connect-button.module.ts
+++ b/packages/dapp-toolkit/src/modules/connect-button/connect-button.module.ts
@@ -208,7 +208,11 @@ export const ConnectButtonModule = (
           )
 
           const showPopoverMenu$ = subjects.showPopoverMenu.pipe(
-            tap((value) => (connectButtonElement.showPopoverMenu = value)),
+            tap((value) => {
+              value
+                ? connectButtonElement.setAttribute('showPopoverMenu', 'true')
+                : connectButtonElement.removeAttribute('showPopoverMenu')
+            }),
           )
 
           const accounts$ = subjects.accounts.pipe(


### PR DESCRIPTION
For some reason `attributeChangedCallback` is not firing when you only do `element.showPopoverMenu = true`. Because of that I'm adjusting way RDT updates this value. This is needed in order to react and remove body overflow CSS property (make page scrollable again after mask is hidden)