### PR TITLE
fix: remove `proofOfOwnership` from `unathorizedRequest`

### DIFF
--- a/packages/dapp-toolkit/src/modules/wallet-request/data-request/helpers/to-wallet-request.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/data-request/helpers/to-wallet-request.ts
@@ -48,7 +48,7 @@ export const toWalletRequest = ({
           oneTime,
         }
 
-      if (!oneTime) {
+      if (!oneTime || dataRequestState.proofOfOwnership) {
         const persona = walletData.persona
 
         if (walletData.persona) draft.persona = persona

--- a/packages/dapp-toolkit/src/modules/wallet-request/data-request/transformations/rdt-to-wallet.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/data-request/transformations/rdt-to-wallet.ts
@@ -51,7 +51,7 @@ export const TransformRdtDataRequestToWalletRequestInput = object({
 const isAuthorized = (
   input: TransformRdtDataRequestToWalletRequestInput,
 ): boolean => {
-  const { persona, accounts, personaData } = input
+  const { persona, accounts, personaData, proofOfOwnership } = input
 
   const isPersonaLogin = !!persona
   const shouldResetData = accounts?.reset || personaData?.reset
@@ -62,8 +62,9 @@ const isAuthorized = (
     shouldResetData ||
     isOngoingAccountsRequest ||
     isOngoingPersonaDataRequest ||
-    isPersonaLogin
-  )
+    isPersonaLogin ||
+    proofOfOwnership
+  ) 
 
   return isAuthorizedRequest
 }
@@ -130,7 +131,7 @@ const withProofOfOwnershipRequestItem =
       const { challenge, accountAddresses, identityAddress } =
         input.proofOfOwnership
 
-      if (challenge) {
+      if (challenge && updatedRequestItems.discriminator === 'authorizedRequest') {
         updatedRequestItems['proofOfOwnership'] = {
           challenge,
         }

--- a/packages/dapp-toolkit/src/modules/wallet-request/data-request/transformations/wallet-to-rdt.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/data-request/transformations/wallet-to-rdt.ts
@@ -150,6 +150,15 @@ const withProofs =
           )
           draft.proofs.push(...accountProofs)
         }
+
+        if (input.proofOfOwnership) {
+          draft.proofs.push(
+            ...convertOwnershipProofsToSignedChallenge(
+              input.proofOfOwnership.challenge,
+              input.proofOfOwnership.proofs,
+            ),
+          )
+        }
       }
       if (input.discriminator === 'unauthorizedRequest') {
         if (
@@ -167,14 +176,6 @@ const withProofs =
           )
           draft.proofs.push(...accountProofs)
         }
-      }
-      if (input.proofOfOwnership) {
-        draft.proofs.push(
-          ...convertOwnershipProofsToSignedChallenge(
-            input.proofOfOwnership.challenge,
-            input.proofOfOwnership.proofs,
-          ),
-        )
       }
     })
 

--- a/packages/dapp-toolkit/src/modules/wallet-request/wallet-request.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/wallet-request.ts
@@ -340,7 +340,9 @@ export const WalletRequestModule = (input: {
             !state.walletData.persona &&
             walletDataRequest.discriminator === 'authorizedRequest'
 
-          const isProofOfOwnershipRequest = !!walletDataRequest.proofOfOwnership
+          const isProofOfOwnershipRequest =
+            walletDataRequest.discriminator === 'authorizedRequest' &&
+            !!walletDataRequest.proofOfOwnership
 
           const requestType = isLoginRequest
             ? 'loginRequest'

--- a/packages/dapp-toolkit/src/schemas/index.ts
+++ b/packages/dapp-toolkit/src/schemas/index.ts
@@ -153,7 +153,6 @@ export type WalletUnauthorizedRequestItems = InferOutput<
 >
 export const WalletUnauthorizedRequestItems = object({
   discriminator: literal('unauthorizedRequest'),
-  proofOfOwnership: optional(ProofOfOwnershipRequestItem),
   oneTimeAccounts: optional(AccountsRequestItem),
   oneTimePersonaData: optional(PersonaDataRequestItem),
 })
@@ -271,7 +270,6 @@ export type WalletUnauthorizedRequestResponseItems = InferOutput<
 >
 const WalletUnauthorizedRequestResponseItems = object({
   discriminator: literal('unauthorizedRequest'),
-  proofOfOwnership: optional(ProofOfOwnershipResponseItem),
   oneTimeAccounts: optional(AccountsRequestResponseItem),
   oneTimePersonaData: optional(PersonaDataRequestResponseItem),
 })


### PR DESCRIPTION
Proof Of Ownership can only be part of authorized request. 

Example proof of ownership interaction
```
 {
     interactionId: 'f3247646-6efe-4670-a175-e69dff5a7169',
     interaction: 
      {
        items: 
         {
           discriminator: 'authorizedRequest',
           auth: 
            {
              discriminator: 'usePersona',
              identityAddress: 'identity_tdx_2_12f0rqnrmvqfh0uq337hlzthm9z9xjqwl92js0ptrlapnyc3ewrvu2x' 
            },
           reset: 
            {
              accounts: false,
              personaData: false 
            },
           proofOfOwnership: 
            {
              challenge: 'ab191a8b287dcf901613897de4f7dd475af8e665d0b0e668ea90b52bbd07b583',
              accountAddresses: 
               [
                 'account_tdx_2_128t9g985y4uje99er3zkm2gngxcen2cwg7m8zn32ux4smh37ydp5n6' 
               ],
              identityAddress: 'identity_tdx_2_12f0rqnrmvqfh0uq337hlzthm9z9xjqwl92js0ptrlapnyc3ewrvu2x' 
            } 
         },
        interactionId: 'f3247646-6efe-4670-a175-e69dff5a7169',
        metadata: 
         {
           version: 2,
           dAppDefinitionAddress: 'account_tdx_2_12yf9gd53yfep7a669fv2t3wm7nz9zeezwd04n02a433ker8vza6rhe',
           networkId: 2,
           origin: 'http://localhost:5173' 
         } 
      },
```
