### PR TITLE
fix: call `onTransactionId` immediately when tx id is available

### DIFF
--- a/packages/dapp-toolkit/README.md
+++ b/packages/dapp-toolkit/README.md
@@ -449,7 +449,9 @@ Radix transactions are built using "transaction manifests", that use a simple sy
 
 It is important to note that what your dApp sends to the Radix Wallet is actually a "transaction manifest stub". It is completed before submission by the Radix Wallet. For example, the Radix Wallet will automatically add a command to lock the necessary amount of network fees from one of the user's accounts. It may also add "assert" commands to the manifest according to user desires for expected returns.
 
-**NOTE:** Information will be provided soon on a ["comforming" transaction manifest stub format](https://docs.radixdlt.com/docs/conforming-transaction-manifest-types) that ensures clear presentation and handling in the Radix Wallet.
+> [!NOTE]
+> Some of the manifests will have a nice presentation in the Radix Wallet, others will be displayed as raw text. Read more on ["comforming" transaction manifest stub format](https://docs.radixdlt.com/docs/conforming-transaction-manifest-types).
+
 
 ### Build transaction manifest
 
@@ -457,7 +459,7 @@ We recommend using template strings for constructing simpler transaction manifes
 
 ### sendTransaction
 
-This sends the transaction manifest stub to a user's Radix Wallet, where it will be completed, presented to the user for review, signed as required, and submitted to the Radix network to be processed.
+This sends the transaction manifest stub to a user's Radix Wallet, where it will be completed, presented to the user for review, signed as required, and submitted to the Radix network to be processed. `sendTransaction` promise will only be resolved after transaction has been committed to the network (either successfuly or rejected/failure). If you want to do your own logic as soon as transaction id is available, please use `onTransactionId` callback. It will be called immediately after RDT receives response from the Radix Wallet.
 
 ```typescript
 type SendTransactionInput = {

--- a/packages/dapp-toolkit/src/modules/wallet-request/request-items/request-item.module.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/request-items/request-item.module.ts
@@ -61,7 +61,7 @@ export const RequestItemModule = (input: RequestItemModuleInput) => {
       .map(() => item)
   }
 
-  const maybeGetSignal = (interactionId: string) => {
+  const getAndRemoveSignal = (interactionId: string) => {
     if (signals.has(interactionId)) {
       const signal = signals.get(interactionId)
       signals.delete(interactionId)
@@ -154,7 +154,7 @@ export const RequestItemModule = (input: RequestItemModuleInput) => {
     cancel,
     updateStatus,
     patch,
-    maybeGetSignal,
+    getAndRemoveSignal,
     getById: (id: string) => storageModule.getItemById(id),
     getPending,
     requests$,

--- a/packages/dapp-toolkit/src/modules/wallet-request/request-resolver/request-resolver.module.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/request-resolver/request-resolver.module.ts
@@ -4,9 +4,7 @@ import type { WalletInteractionResponse } from '../../../schemas'
 import type { StorageModule } from '../../storage'
 import type { RequestItemModule } from '../request-items'
 import { SdkError } from '../../../error'
-import { StateModule } from '../../state'
 import { filter, firstValueFrom, map } from 'rxjs'
-import { GatewayModule } from '../../gateway'
 import { WalletResponseResolver } from './type'
 import { RequestItem } from 'radix-connect-common'
 
@@ -14,11 +12,8 @@ export type RequestResolverModule = ReturnType<typeof RequestResolverModule>
 export const RequestResolverModule = (input: {
   logger?: Logger
   providers: {
-    stateModule: StateModule
     storageModule: StorageModule
     requestItemModule: RequestItemModule
-    updateConnectButtonStatus: (status: 'fail' | 'success') => void
-    gatewayModule: GatewayModule
     resolvers: WalletResponseResolver[]
   }
 }) => {

--- a/packages/dapp-toolkit/src/modules/wallet-request/request-resolver/resolvers/pre-authorization-response.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/request-resolver/resolvers/pre-authorization-response.ts
@@ -6,7 +6,6 @@ import {
 import { RequestItemModule } from '../../request-items'
 import { SdkError } from '../../../../error'
 import { UpdateConnectButtonStatus, WalletResponseResolver } from '../type'
-import { RequestStatus } from 'radix-connect-common'
 
 const matchResponse = (
   input: WalletInteractionResponse,

--- a/packages/dapp-toolkit/src/modules/wallet-request/request-resolver/resolvers/pre-authorization-response.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/request-resolver/resolvers/pre-authorization-response.ts
@@ -1,17 +1,21 @@
 import { err, okAsync } from 'neverthrow'
-import { WalletInteractionResponse } from '../../../../schemas'
+import {
+  SubintentResponseItem,
+  WalletInteractionResponse,
+} from '../../../../schemas'
 import { RequestItemModule } from '../../request-items'
 import { SdkError } from '../../../../error'
 import { UpdateConnectButtonStatus, WalletResponseResolver } from '../type'
+import { RequestStatus } from 'radix-connect-common'
 
 const matchResponse = (
   input: WalletInteractionResponse,
-): string | undefined => {
+): SubintentResponseItem | undefined => {
   if (
     input.discriminator === 'success' &&
     input.items.discriminator === 'preAuthorizationResponse'
   ) {
-    return input.items.response?.signedPartialTransaction
+    return input.items.response
   }
 }
 
@@ -21,8 +25,10 @@ export const preAuthorizationResponseResolver =
     updateConnectButtonStatus: UpdateConnectButtonStatus
   }): WalletResponseResolver =>
   ({ walletInteraction, walletInteractionResponse }) => {
-    const signedPartialTransaction = matchResponse(walletInteractionResponse)
-    if (!signedPartialTransaction) return okAsync(undefined)
+    const response = matchResponse(walletInteractionResponse)
+    if (!response) return okAsync(undefined)
+    const { signedPartialTransaction, expirationTimestamp, subintentHash } =
+      response
 
     const { interactionId } = walletInteraction
 
@@ -34,6 +40,8 @@ export const preAuthorizationResponseResolver =
         status: 'success',
         metadata: {
           signedPartialTransaction,
+          expirationTimestamp,
+          subintentHash,
         },
       })
       .orElse((error) => {

--- a/packages/dapp-toolkit/src/modules/wallet-request/request-resolver/resolvers/send-transaction-response.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/request-resolver/resolvers/send-transaction-response.ts
@@ -50,7 +50,7 @@ export const sendTransactionResponseResolver =
       .getById(interactionId)
       .mapErr(() => SdkError('FailedToGetItemWithInteractionId', interactionId))
       .andTee(() =>
-        requestItemModule.maybeGetSignal(interactionId)?.(
+        requestItemModule.getAndRemoveSignal(interactionId)?.(
           transactionIntentHash,
         ),
       )

--- a/packages/dapp-toolkit/src/modules/wallet-request/request-resolver/resolvers/send-transaction-response.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/request-resolver/resolvers/send-transaction-response.ts
@@ -46,8 +46,15 @@ export const sendTransactionResponseResolver =
       send: { transactionIntentHash },
     } = transactionResponse
 
-    return gatewayModule
-      .pollTransactionStatus(transactionIntentHash)
+    return requestItemModule
+      .getById(interactionId)
+      .mapErr(() => SdkError('FailedToGetItemWithInteractionId', interactionId))
+      .andTee(() =>
+        requestItemModule.maybeGetSignal(interactionId)?.(
+          transactionIntentHash,
+        ),
+      )
+      .andThen(() => gatewayModule.pollTransactionStatus(transactionIntentHash))
       .andThen(({ status }) => {
         const isFailedTransaction = determineFailedTransaction(status)
         const requestItemStatus = isFailedTransaction ? 'fail' : 'success'

--- a/packages/dapp-toolkit/src/modules/wallet-request/wallet-request.spec.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/wallet-request.spec.ts
@@ -1,0 +1,132 @@
+import { Logger } from './../../helpers/logger'
+import { describe, expect, it, vi } from 'vitest'
+import { WalletRequestModule } from './wallet-request'
+import { GatewayModule, RadixNetwork, TransactionStatus } from '../gateway'
+import { LocalStorageModule } from '../storage'
+import { ok, okAsync, ResultAsync } from 'neverthrow'
+import { WalletInteractionItems } from '../../schemas'
+import {
+  RequestResolverModule,
+  sendTransactionResponseResolver,
+} from './request-resolver'
+import { RequestItemModule } from './request-items'
+import { delayAsync } from '../../test-helpers/delay-async'
+
+const createMockEnvironment = () => {
+  const storageModule = LocalStorageModule(`rdt:${crypto.randomUUID()}:1`)
+  const requestItemModule = RequestItemModule({
+    providers: {
+      storageModule,
+    },
+  })
+  const gatewayModule = {
+    pollTransactionStatus: (hash: string) =>
+      ResultAsync.fromSafePromise(delayAsync(2000)).map(() =>
+        ok({ status: 'success' as TransactionStatus }),
+      ),
+  } as any
+  const updateConnectButtonStatus = () => {}
+  const stateModule = {} as any
+  return {
+    storageModule,
+    requestItemModule,
+    gatewayModule,
+    updateConnectButtonStatus,
+    stateModule,
+  }
+}
+
+describe('WalletRequestModule', () => {
+  describe('given `onTransactionId` callback is provided', () => {
+    it('should call the callback before polling is finished', async () => {
+      // Arange
+      const {
+        storageModule,
+        requestItemModule,
+        gatewayModule,
+        updateConnectButtonStatus,
+        stateModule,
+      } = createMockEnvironment()
+
+      const requestResolverModule = RequestResolverModule({
+        providers: {
+          stateModule,
+          gatewayModule,
+          storageModule,
+          requestItemModule,
+          resolvers: [
+            sendTransactionResponseResolver({
+              gatewayModule,
+              requestItemModule,
+              updateConnectButtonStatus,
+            }),
+          ],
+          updateConnectButtonStatus,
+        },
+      })
+
+      const interactionId = 'abcdef'
+      const resultReturned = vi.fn()
+      const onTransactionIdSpy = vi.fn()
+
+      const walletRequestModule = WalletRequestModule({
+        useCache: false,
+        networkId: RadixNetwork.Stokenet,
+        dAppDefinitionAddress: '',
+        providers: {
+          stateModule: {} as any,
+          storageModule,
+          requestItemModule,
+          requestResolverModule,
+          gatewayModule,
+          walletRequestSdk: {
+            sendInteraction: () => okAsync({}),
+            createWalletInteraction: (items: WalletInteractionItems) => ({
+              items,
+              interactionId,
+              metadata: {} as any,
+            }),
+          } as any,
+        },
+      })
+
+      // Act
+      walletRequestModule
+        .sendTransaction({
+          transactionManifest: ``,
+          onTransactionId: onTransactionIdSpy,
+        })
+        .map(resultReturned)
+
+      await delayAsync(50)
+
+      requestResolverModule.addWalletResponses([
+        {
+          interactionId,
+          discriminator: 'success',
+          items: {
+            discriminator: 'transaction',
+            send: {
+              transactionIntentHash: 'intent_hash',
+            },
+          },
+        },
+      ])
+
+      // Assert
+      expect(resultReturned).not.toHaveBeenCalled()
+      await expect
+        .poll(() => onTransactionIdSpy, {
+          timeout: 1000,
+        })
+        .toHaveBeenCalledWith('intent_hash')
+      await expect
+        .poll(() => resultReturned, {
+          timeout: 3000,
+        })
+        .toHaveBeenCalledWith(
+          expect.objectContaining({ transactionIntentHash: 'intent_hash' }),
+        )
+    })
+  })
+})

--- a/packages/dapp-toolkit/src/modules/wallet-request/wallet-request.spec.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/wallet-request.spec.ts
@@ -26,13 +26,11 @@ const createMockEnvironment = () => {
       ),
   } as any
   const updateConnectButtonStatus = () => {}
-  const stateModule = {} as any
   return {
     storageModule,
     requestItemModule,
     gatewayModule,
     updateConnectButtonStatus,
-    stateModule,
   }
 }
 
@@ -45,13 +43,10 @@ describe('WalletRequestModule', () => {
         requestItemModule,
         gatewayModule,
         updateConnectButtonStatus,
-        stateModule,
       } = createMockEnvironment()
 
       const requestResolverModule = RequestResolverModule({
         providers: {
-          stateModule,
-          gatewayModule,
           storageModule,
           requestItemModule,
           resolvers: [
@@ -61,7 +56,6 @@ describe('WalletRequestModule', () => {
               updateConnectButtonStatus,
             }),
           ],
-          updateConnectButtonStatus,
         },
       })
 

--- a/packages/dapp-toolkit/src/modules/wallet-request/wallet-request.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/wallet-request.ts
@@ -100,7 +100,6 @@ export const WalletRequestModule = (input: {
       providers: {
         storageModule,
         requestItemModule,
-        stateModule,
         resolvers: [
           sendTransactionResponseResolver({
             gatewayModule,
@@ -122,10 +121,6 @@ export const WalletRequestModule = (input: {
             updateConnectButtonStatus,
           }),
         ],
-        updateConnectButtonStatus: (status) => {
-          interactionStatusChangeSubject.next(status)
-        },
-        gatewayModule,
       },
     })
 

--- a/packages/dapp-toolkit/src/modules/wallet-request/wallet-request.ts
+++ b/packages/dapp-toolkit/src/modules/wallet-request/wallet-request.ts
@@ -429,11 +429,14 @@ export const WalletRequestModule = (input: {
       })
 
       return requestItemModule
-        .add({
-          type: 'sendTransaction',
-          walletInteraction,
-          isOneTimeRequest: false,
-        })
+        .add(
+          {
+            type: 'sendTransaction',
+            walletInteraction,
+            isOneTimeRequest: false,
+          },
+          value.onTransactionId,
+        )
         .mapErr(() =>
           SdkError('FailedToAddRequestItem', walletInteraction.interactionId),
         )
@@ -449,9 +452,6 @@ export const WalletRequestModule = (input: {
           transactionIntentHash: transactionIntentHash!,
           status: metadata!.transactionStatus as TransactionStatus,
         }
-
-        if (value.onTransactionId)
-          value.onTransactionId(output.transactionIntentHash)
 
         return status === 'success'
           ? ok(output)

--- a/packages/dapp-toolkit/src/schemas/index.ts
+++ b/packages/dapp-toolkit/src/schemas/index.ts
@@ -274,6 +274,8 @@ export const SubintentRequestItem = object({
 
 export type SubintentResponseItem = InferOutput<typeof SubintentResponseItem>
 export const SubintentResponseItem = object({
+  expirationTimestamp: number(),
+  subintentHash: string(),
   signedPartialTransaction: string(),
 })
 

--- a/packages/dapp-toolkit/src/test-helpers/delay-async.ts
+++ b/packages/dapp-toolkit/src/test-helpers/delay-async.ts
@@ -1,0 +1,6 @@
+export const delayAsync = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve()
+    }, ms)
+  })


### PR DESCRIPTION
Previously it was called only after gateway polling has finished which is not what it was intended to do.